### PR TITLE
Retrait duplicata exemple NBA et corrections mineures

### DIFF
--- a/notes_de_cours/Séance1_CM.ipynb
+++ b/notes_de_cours/Séance1_CM.ipynb
@@ -2007,6 +2007,1999 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ea75961d-8e64-432a-b425-1cbbaa57e611",
+   "metadata": {},
+   "source": [
+    "#### Création de tableaux"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abbaa4f3",
+   "metadata": {},
+   "source": [
+    "Pour utiliser les tableaux, il faut importer le module pandas, la librairie python la plus utilisée pour la manipulation de données"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9328d4b2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:32.738749Z",
+     "start_time": "2024-10-01T09:10:32.734727Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aff45a03",
+   "metadata": {},
+   "source": [
+    "Des tables vides peuvent être créées à l'aide de la fonction `DataFrame` du module pandas. Un tableau vide est utile car il peut être étendu pour contenir de nouvelles lignes et colonnes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "43beb98b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:33.647941Z",
+     "start_time": "2024-10-01T09:10:33.643091Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pandas.DataFrame()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc154a46",
+   "metadata": {},
+   "source": [
+    "On peut ajouter une colonne en indexant une table par le nom de la colonne souhaitée et en lui assignant la liste des valeurs souhaitée dans cette colonne pour chaque ligne du tableau.\n",
+    "\n",
+    "Par exemple pour créer une colonne `Number of petals` dans notre table vide :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "45253fdf",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:34.499391Z",
+     "start_time": "2024-10-01T09:10:34.492849Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Number of petals</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>34</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Number of petals\n",
+       "0                 8\n",
+       "1                34\n",
+       "2                 5"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df['Number of petals'] = [8, 34, 5]\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f924496",
+   "metadata": {},
+   "source": [
+    "Pour ajouter deux colonnes (ou plus), on peut les ajouter une par une (attention toutes les colonnes doivent avoir la même longueur, sinon une erreur se produira). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "ede5412c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:35.544800Z",
+     "start_time": "2024-10-01T09:10:35.533856Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Number of petals</th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Color</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8</td>\n",
+       "      <td>lotus</td>\n",
+       "      <td>pink</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>34</td>\n",
+       "      <td>sunflower</td>\n",
+       "      <td>yellow</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5</td>\n",
+       "      <td>rose</td>\n",
+       "      <td>red</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Number of petals       Name   Color\n",
+       "0                 8      lotus    pink\n",
+       "1                34  sunflower  yellow\n",
+       "2                 5       rose     red"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flowers = pandas.DataFrame()\n",
+    "flowers['Number of petals'] = [8, 34, 5]\n",
+    "flowers['Name'] = ['lotus', 'sunflower', 'rose']\n",
+    "flowers['Color'] = ['pink', 'yellow', 'red']\n",
+    "\n",
+    "flowers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "925eb8be",
+   "metadata": {},
+   "source": [
+    "Nous pouvons aussi créer un tableau directement en spécifiant les noms des colonnes comme clés d'un [dictionnaire python](https://www.w3schools.com/PYTHON/python_dictionaries.asp) avec comme valeurs associé à chaque clé, la liste des valeurs souhaitée dans la colonne correspondante. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "d9bb68fb",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:37.063446Z",
+     "start_time": "2024-10-01T09:10:37.052596Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Number of petals</th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Color</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>8</td>\n",
+       "      <td>lotus</td>\n",
+       "      <td>pink</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>34</td>\n",
+       "      <td>sunflower</td>\n",
+       "      <td>yellow</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>5</td>\n",
+       "      <td>rose</td>\n",
+       "      <td>red</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Number of petals       Name   Color\n",
+       "0                 8      lotus    pink\n",
+       "1                34  sunflower  yellow\n",
+       "2                 5       rose     red"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "flowers_dict = {'Number of petals' : [8, 34, 5],\n",
+    "                'Name' : ['lotus', 'sunflower', 'rose'],\n",
+    "                'Color' : ['pink', 'yellow', 'red']\n",
+    "}\n",
+    "\n",
+    "flowers = pandas.DataFrame(flowers_dict)\n",
+    "flowers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5e1a263",
+   "metadata": {},
+   "source": [
+    "La création de tableaux de cette manière implique beaucoup de saisie. Si les données ont déjà été saisies quelque part, il est généralement possible d'utiliser Python pour les lire dans un tableau, au lieu de les saisir cellule par cellule.\n",
+    "\n",
+    "Souvent, les tableaux sont créés à partir de fichiers contenant des valeurs séparées par des virgules. Ces fichiers sont appelés fichiers CSV.\n",
+    "\n",
+    "Ci-dessous, nous utilisons la méthode Table `read_csv` de la librairie pandas pour lire un fichier CSV qui contient certaines des données utilisées par Minard dans son graphique sur la campagne russe de Napoléon. Les données sont placées dans une table nommée `minard`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "5825f203",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:38.021443Z",
+     "start_time": "2024-10-01T09:10:38.012483Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude         City Direction  Survivors\n",
+       "0       32.0      54.8     Smolensk   Advance     145000\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
+       "2       34.4      55.5        Chjat   Advance     127100\n",
+       "3       37.6      55.8       Moscou   Advance     100000\n",
+       "4       34.3      55.2        Wixma   Retreat      55000\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000\n",
+       "6       30.4      54.4       Orscha   Retreat      20000\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard = pandas.read_csv(path_data + 'minard.csv')\n",
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c945f439",
+   "metadata": {},
+   "source": [
+    "Nous utiliserons ce petit tableau pour démontrer certaines méthodes utiles. Nous utiliserons ensuite ces mêmes méthodes, et en développerons d'autres, sur des tableaux de données beaucoup plus importants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9af7fc2c",
+   "metadata": {},
+   "source": [
+    "#### La taille de la table\n",
+    "\n",
+    "La méthode `len` appliquée à l'attribut `columns` d'un tableau donne le nombre de colonnes du tableau, et `len` appliqué directement au tableau lui-même donne le nombre de lignes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "fb2f8ac6",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:39.329181Z",
+     "start_time": "2024-10-01T09:10:39.324512Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(minard.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "5779c3c0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:40.376490Z",
+     "start_time": "2024-10-01T09:10:40.372225Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(minard)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "159574bc",
+   "metadata": {},
+   "source": [
+    "#### Étiquettes des colonnes\n",
+    "\n",
+    "La méthode `columns` peut être utilisée pour lister les étiquettes de toutes les colonnes. Avec `minard`, cela ne nous apporte pas grand chose, mais cela peut être très utile pour les tableaux qui sont si grands que toutes les colonnes ne sont pas visibles à l'écran."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "f623f9c2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:41.403427Z",
+     "start_time": "2024-10-01T09:10:41.399581Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['Longitude', 'Latitude', 'City', 'Direction', 'Survivors'], dtype='object')"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42d5e377",
+   "metadata": {},
+   "source": [
+    "Nous pouvons changer les étiquettes des colonnes en utilisant la méthode `relabeled`. Cette méthode crée une nouvelle table et laisse `minard` inchangé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "d8c37299",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:41.956951Z",
+     "start_time": "2024-10-01T09:10:41.949224Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude    City Name Direction  Survivors\n",
+       "0       32.0      54.8     Smolensk   Advance     145000\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
+       "2       34.4      55.5        Chjat   Advance     127100\n",
+       "3       37.6      55.8       Moscou   Advance     100000\n",
+       "4       34.3      55.2        Wixma   Retreat      55000\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000\n",
+       "6       30.4      54.4       Orscha   Retreat      20000\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.rename(columns={'City': 'City Name'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5baf6f6",
+   "metadata": {},
+   "source": [
+    "Toutefois, cette méthode ne modifie pas le tableau original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "2aee95b5",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:42.638754Z",
+     "start_time": "2024-10-01T09:10:42.629880Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude         City Direction  Survivors\n",
+       "0       32.0      54.8     Smolensk   Advance     145000\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
+       "2       34.4      55.5        Chjat   Advance     127100\n",
+       "3       37.6      55.8       Moscou   Advance     100000\n",
+       "4       34.3      55.2        Wixma   Retreat      55000\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000\n",
+       "6       30.4      54.4       Orscha   Retreat      20000\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "196e6c8b",
+   "metadata": {},
+   "source": [
+    "Il est courant d'attribuer le nom original `minard` à la nouvelle table, de sorte que toutes les utilisations futures de `minard` fassent référence à la table réétiquetée."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "53986932",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:43.450883Z",
+     "start_time": "2024-10-01T09:10:43.441717Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude    City Name Direction  Survivors\n",
+       "0       32.0      54.8     Smolensk   Advance     145000\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
+       "2       34.4      55.5        Chjat   Advance     127100\n",
+       "3       37.6      55.8       Moscou   Advance     100000\n",
+       "4       34.3      55.2        Wixma   Retreat      55000\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000\n",
+       "6       30.4      54.4       Orscha   Retreat      20000\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard = minard.rename(columns={'City': 'City Name'})\n",
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29a817fb",
+   "metadata": {},
+   "source": [
+    "#### Accéder aux données d'une colonne\n",
+    "\n",
+    "Nous pouvons utiliser l'étiquette d'une colonne pour accéder au tableau de données qu'elle contient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "e4c4b2e4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:44.797680Z",
+     "start_time": "2024-10-01T09:10:44.793725Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    145000\n",
+       "1    140000\n",
+       "2    127100\n",
+       "3    100000\n",
+       "4     55000\n",
+       "5     24000\n",
+       "6     20000\n",
+       "7     12000\n",
+       "Name: Survivors, dtype: int64"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard['Survivors']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73531310",
+   "metadata": {},
+   "source": [
+    "Les 5 colonnes sont indexées 0, 1, 2, 3 et 4. La colonne `Survivants` peut également être accédée en utilisant l'index de sa colonne (4). Pour cela, il faut utiliser l'attribut `iloc` qui permet d'utiliser le tableau pandas comme un tableau numpy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "67949c8c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:45.771839Z",
+     "start_time": "2024-10-01T09:10:45.767559Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    145000\n",
+       "1    140000\n",
+       "2    127100\n",
+       "3    100000\n",
+       "4     55000\n",
+       "5     24000\n",
+       "6     20000\n",
+       "7     12000\n",
+       "Name: Survivors, dtype: int64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.iloc[:,4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a81e23a",
+   "metadata": {},
+   "source": [
+    "Les 8 éléments du tableau sont indexés 0, 1, 2, et ainsi de suite jusqu'à 7. On peut accéder aux éléments de la colonne en continuant d'utiliser `iloc`, comme pour tout tableau numpy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "9857947b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:47.210526Z",
+     "start_time": "2024-10-01T09:10:47.206184Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.int64(145000)"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.iloc[0,4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "d39b8a38",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:48.250514Z",
+     "start_time": "2024-10-01T09:10:48.247164Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.int64(145000)"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard['Survivors'][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e6003d4",
+   "metadata": {},
+   "source": [
+    "#### Travailler avec les données d'une colonne\n",
+    "\n",
+    "Les colonnes étant des tableaux, nous pouvons utiliser des opérations sur les tableaux pour découvrir de nouvelles informations. Par exemple, nous pouvons créer une nouvelle colonne contenant le pourcentage de tous les survivants dans chaque ville après Smolensk."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "9b296449",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:48.941809Z",
+     "start_time": "2024-10-01T09:10:48.933872Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "      <th>Percent Surviving</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "      <td>0.965517</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "      <td>0.876552</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>0.689655</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "      <td>0.379310</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "      <td>0.165517</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "      <td>0.137931</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "      <td>0.082759</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude    City Name Direction  Survivors  Percent Surviving\n",
+       "0       32.0      54.8     Smolensk   Advance     145000           1.000000\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000           0.965517\n",
+       "2       34.4      55.5        Chjat   Advance     127100           0.876552\n",
+       "3       37.6      55.8       Moscou   Advance     100000           0.689655\n",
+       "4       34.3      55.2        Wixma   Retreat      55000           0.379310\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000           0.165517\n",
+       "6       30.4      54.4       Orscha   Retreat      20000           0.137931\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000           0.082759"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "initial = minard['Survivors'][0]\n",
+    "minard['Percent Surviving'] = minard['Survivors']/initial\n",
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9ff9391",
+   "metadata": {},
+   "source": [
+    "Pour que les proportions dans les nouvelles colonnes apparaissent sous forme de pourcentages, nous pouvons utiliser la méthode `.style.format` avec le format `{:,.2%}`. Ici, les accolades et les deux points `{:}` sont obligatoires, le `.2` signifie que l'on veut garder deux chiffres après la virgule, et le `%` signifie que l'on veut un pourcentage. Les options de formatages sont disponibles sur ce lien (en anglais) [https://fstring.help/cheat/](https://fstring.help/cheat/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "bfd7e54f",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:49.622164Z",
+     "start_time": "2024-10-01T09:10:49.610264Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "      <th>Percent Surviving</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "      <td>100.00%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "      <td>96.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "      <td>87.66%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>68.97%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "      <td>37.93%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "      <td>16.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "      <td>13.79%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "      <td>8.28%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude    City Name Direction  Survivors Percent Surviving\n",
+       "0       32.0      54.8     Smolensk   Advance     145000           100.00%\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000            96.55%\n",
+       "2       34.4      55.5        Chjat   Advance     127100            87.66%\n",
+       "3       37.6      55.8       Moscou   Advance     100000            68.97%\n",
+       "4       34.3      55.2        Wixma   Retreat      55000            37.93%\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000            16.55%\n",
+       "6       30.4      54.4       Orscha   Retreat      20000            13.79%\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000             8.28%"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard['Percent Surviving'] = minard['Percent Surviving'].map('{:,.2%}'.format)\n",
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45264341",
+   "metadata": {},
+   "source": [
+    "#### Choisir des ensembles de colonnes\n",
+    "\n",
+    "Pour créer une nouvelle table qui ne contient que les colonnes spécifiées, on peut utiliser une nouvelle liste Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "dfdb894e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:50.548043Z",
+     "start_time": "2024-10-01T09:10:50.537907Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude\n",
+       "0       32.0      54.8\n",
+       "1       33.2      54.9\n",
+       "2       34.4      55.5\n",
+       "3       37.6      55.8\n",
+       "4       34.3      55.2\n",
+       "5       32.0      54.6\n",
+       "6       30.4      54.4\n",
+       "7       26.8      54.3"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard[['Longitude', 'Latitude']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "416f5d81",
+   "metadata": {},
+   "source": [
+    "La même sélection peut être effectuée en utilisant des indices de colonne au lieu d'étiquettes à l'aide de la méthode `iloc`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "0d814895",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:51.907598Z",
+     "start_time": "2024-10-01T09:10:51.900750Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude\n",
+       "0       32.0      54.8\n",
+       "1       33.2      54.9\n",
+       "2       34.4      55.5\n",
+       "3       37.6      55.8\n",
+       "4       34.3      55.2\n",
+       "5       32.0      54.6\n",
+       "6       30.4      54.4\n",
+       "7       26.8      54.3"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.iloc[:,[0, 1]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1624aab7",
+   "metadata": {},
+   "source": [
+    "La sélection d'une colonne est un nouveau tableau, même si vous ne sélectionnez qu'une seule colonne."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "92604851",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:52.822162Z",
+     "start_time": "2024-10-01T09:10:52.818510Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    145000\n",
+       "1    140000\n",
+       "2    127100\n",
+       "3    100000\n",
+       "4     55000\n",
+       "5     24000\n",
+       "6     20000\n",
+       "7     12000\n",
+       "Name: Survivors, dtype: int64"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard['Survivors']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24f42b73",
+   "metadata": {},
+   "source": [
+    "Une autre façon de créer une nouvelle table composée d'un ensemble de colonnes est de \"supprimer\" les colonnes dont vous ne voulez pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "64a8fa99",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:53.937660Z",
+     "start_time": "2024-10-01T09:10:53.928165Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Survivors</th>\n",
+       "      <th>Percent Surviving</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>145000</td>\n",
+       "      <td>100.00%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>140000</td>\n",
+       "      <td>96.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>127100</td>\n",
+       "      <td>87.66%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>68.97%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>55000</td>\n",
+       "      <td>37.93%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>24000</td>\n",
+       "      <td>16.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>20000</td>\n",
+       "      <td>13.79%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>12000</td>\n",
+       "      <td>8.28%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     City Name  Survivors Percent Surviving\n",
+       "0     Smolensk     145000           100.00%\n",
+       "1  Dorogobouge     140000            96.55%\n",
+       "2        Chjat     127100            87.66%\n",
+       "3       Moscou     100000            68.97%\n",
+       "4        Wixma      55000            37.93%\n",
+       "5     Smolensk      24000            16.55%\n",
+       "6       Orscha      20000            13.79%\n",
+       "7    Moiodexno      12000             8.28%"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard.drop(columns=['Longitude', 'Latitude', 'Direction'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d7f22cc",
+   "metadata": {},
+   "source": [
+    "Ni la selection ni `drop` ne modifient la table d'origine. Au lieu de cela, ils créent de nouvelles tables plus petites qui partagent les mêmes données. Le fait que la table originale soit préservée est utile ! Vous pouvez générer plusieurs tableaux différents qui ne prennent en compte que certaines colonnes sans craindre qu'une analyse n'affecte l'autre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "28da3c59",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-01T09:10:55.353878Z",
+     "start_time": "2024-10-01T09:10:55.340941Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Longitude</th>\n",
+       "      <th>Latitude</th>\n",
+       "      <th>City Name</th>\n",
+       "      <th>Direction</th>\n",
+       "      <th>Survivors</th>\n",
+       "      <th>Percent Surviving</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.8</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>145000</td>\n",
+       "      <td>100.00%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>33.2</td>\n",
+       "      <td>54.9</td>\n",
+       "      <td>Dorogobouge</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>140000</td>\n",
+       "      <td>96.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>34.4</td>\n",
+       "      <td>55.5</td>\n",
+       "      <td>Chjat</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>127100</td>\n",
+       "      <td>87.66%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>37.6</td>\n",
+       "      <td>55.8</td>\n",
+       "      <td>Moscou</td>\n",
+       "      <td>Advance</td>\n",
+       "      <td>100000</td>\n",
+       "      <td>68.97%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34.3</td>\n",
+       "      <td>55.2</td>\n",
+       "      <td>Wixma</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>55000</td>\n",
+       "      <td>37.93%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>32.0</td>\n",
+       "      <td>54.6</td>\n",
+       "      <td>Smolensk</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>24000</td>\n",
+       "      <td>16.55%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>30.4</td>\n",
+       "      <td>54.4</td>\n",
+       "      <td>Orscha</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>20000</td>\n",
+       "      <td>13.79%</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>26.8</td>\n",
+       "      <td>54.3</td>\n",
+       "      <td>Moiodexno</td>\n",
+       "      <td>Retreat</td>\n",
+       "      <td>12000</td>\n",
+       "      <td>8.28%</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Longitude  Latitude    City Name Direction  Survivors Percent Surviving\n",
+       "0       32.0      54.8     Smolensk   Advance     145000           100.00%\n",
+       "1       33.2      54.9  Dorogobouge   Advance     140000            96.55%\n",
+       "2       34.4      55.5        Chjat   Advance     127100            87.66%\n",
+       "3       37.6      55.8       Moscou   Advance     100000            68.97%\n",
+       "4       34.3      55.2        Wixma   Retreat      55000            37.93%\n",
+       "5       32.0      54.6     Smolensk   Retreat      24000            16.55%\n",
+       "6       30.4      54.4       Orscha   Retreat      20000            13.79%\n",
+       "7       26.8      54.3    Moiodexno   Retreat      12000             8.28%"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "minard"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87fa4e16",
+   "metadata": {},
+   "source": [
+    "Toutes les méthodes que nous avons utilisées ci-dessus peuvent être appliquées à n'importe quel tableau."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "06a89e1b-ffa6-49cf-b311-c9b15be9babd",
    "metadata": {},
    "source": [
@@ -2036,7 +4029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 48,
    "id": "3d87441a-8b73-4d7b-a71a-9251af5cf8d5",
    "metadata": {
     "ExecuteTime": {
@@ -2172,7 +4165,7 @@
        "[417 rows x 4 columns]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2191,7 +4184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 49,
    "id": "42dc3416-1bd8-4689-9375-5b297832c347",
    "metadata": {
     "ExecuteTime": {
@@ -2244,7 +4237,7 @@
        "121  Stephen Curry       PG  Golden State Warriors  11.370786"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2263,7 +4256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 50,
    "id": "41140913-d62b-4ddd-bbf8-967eacb2a691",
    "metadata": {
     "ExecuteTime": {
@@ -2420,7 +4413,7 @@
        "130   Anderson Varejao       PF  Golden State Warriors   0.289755"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2440,7 +4433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 51,
    "id": "b420ad41-ff47-4947-bce1-1982c5e92356",
    "metadata": {
     "ExecuteTime": {
@@ -2645,7 +4638,7 @@
        "19       Evan Turner       SG  Boston Celtics   3.425510"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2656,15 +4649,118 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f6f79ac-9407-432b-8075-687d64a0c9f6",
+   "id": "03fc61c8-fac0-494d-94ce-7056e6412f35",
    "metadata": {},
    "source": [
-    "Le tableau `nba` est trié par ordre alphabétique des noms d'équipes. Pour voir comment les joueurs ont été payés en 2015-2016, il est utile de trier les données par salaire. Rappelez-vous que par défaut, le tri se fait par ordre croissant."
+    "Parcourez une vingtaine de lignes et vous verrez qu'elles sont classées par ordre alphabétique du nom de l'équipe. Il est également possible de lister les mêmes lignes dans l'ordre alphabétique des noms de joueurs en utilisant la méthode `sort_values`. L'argument de `sort_values` est un libellé de colonne ou un index."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 52,
+   "id": "bd5ec80d-ee7b-427c-aa6e-54a28a5e8db7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>PLAYER</th>\n",
+       "      <th>POSITION</th>\n",
+       "      <th>TEAM</th>\n",
+       "      <th>SALARY</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>68</th>\n",
+       "      <td>Aaron Brooks</td>\n",
+       "      <td>PG</td>\n",
+       "      <td>Chicago Bulls</td>\n",
+       "      <td>2.250000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>291</th>\n",
+       "      <td>Aaron Gordon</td>\n",
+       "      <td>PF</td>\n",
+       "      <td>Orlando Magic</td>\n",
+       "      <td>4.171680</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>59</th>\n",
+       "      <td>Aaron Harrison</td>\n",
+       "      <td>SG</td>\n",
+       "      <td>Charlotte Hornets</td>\n",
+       "      <td>0.525093</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>235</th>\n",
+       "      <td>Adreian Payne</td>\n",
+       "      <td>PF</td>\n",
+       "      <td>Minnesota Timberwolves</td>\n",
+       "      <td>1.938840</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Al Horford</td>\n",
+       "      <td>C</td>\n",
+       "      <td>Atlanta Hawks</td>\n",
+       "      <td>12.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             PLAYER POSITION                    TEAM     SALARY\n",
+       "68     Aaron Brooks       PG           Chicago Bulls   2.250000\n",
+       "291    Aaron Gordon       PF           Orlando Magic   4.171680\n",
+       "59   Aaron Harrison       SG       Charlotte Hornets   0.525093\n",
+       "235   Adreian Payne       PF  Minnesota Timberwolves   1.938840\n",
+       "1        Al Horford        C           Atlanta Hawks  12.000000"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "nba.sort_values('PLAYER').head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a696d83-fb37-492d-8778-619b6522480d",
+   "metadata": {},
+   "source": [
+    "Pour examiner les salaires des joueurs, il serait beaucoup plus utile que les données soient classées par salaire.\n",
+    "\n",
+    "Pour ce faire, nous allons trier les données en fonction du nouveau libellé \"SALARY\".\n",
+    "\n",
+    "Cela permet de classer toutes les lignes du tableau par ordre *croissant* de salaire, le salaire le plus bas apparaissant en premier. Le résultat est un nouveau tableau avec les mêmes colonnes que l'original mais avec les lignes réarrangées."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
    "id": "b811c866-e689-44bc-b65c-5be62d07e48e",
    "metadata": {
     "ExecuteTime": {
@@ -2800,7 +4896,7 @@
        "[417 rows x 4 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2821,7 +4917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 54,
    "id": "892785aa-e5f7-4609-940c-712d0a69ae54",
    "metadata": {
     "ExecuteTime": {
@@ -2957,7 +5053,7 @@
        "[417 rows x 4 columns]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2969,2760 +5065,11 @@
   {
    "cell_type": "markdown",
    "id": "c0e2ff4b-53d5-42f2-8e9d-08db7779e7db",
-   "metadata": {},
-   "source": [
-    "Le regretté Kobe Bryant a été le joueur de la NBA qui a gagné le plus d'argent en 2015-2016."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ea75961d-8e64-432a-b425-1cbbaa57e611",
-   "metadata": {},
-   "source": [
-    "#### Création de tableaux"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "abbaa4f3",
-   "metadata": {},
-   "source": [
-    "Pour utiliser les tableaux, il faut importer le module pandas, la librairie python la plus utilisée pour la manipulation de données"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "9328d4b2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:32.738749Z",
-     "start_time": "2024-10-01T09:10:32.734727Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import pandas"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "aff45a03",
-   "metadata": {},
-   "source": [
-    "Des tables vides peuvent être créées à l'aide de la fonction `DataFrame` du module pandas. Un tableau vide est utile car il peut être étendu pour contenir de nouvelles lignes et colonnes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "id": "43beb98b",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:33.647941Z",
-     "start_time": "2024-10-01T09:10:33.643091Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df = pandas.DataFrame()\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc154a46",
-   "metadata": {},
-   "source": [
-    "On peut ajouter une colonne en indexant une table par le nom de la colonne souhaitée et en lui assignant la liste des valeurs souhaitée dans cette colonne pour chaque ligne du tableau.\n",
-    "\n",
-    "Par exemple pour créer une colonne `Number of petals` dans notre table vide :"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "45253fdf",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:34.499391Z",
-     "start_time": "2024-10-01T09:10:34.492849Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Number of petals</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>34</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Number of petals\n",
-       "0                 8\n",
-       "1                34\n",
-       "2                 5"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "df['Number of petals'] = [8, 34, 5]\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9f924496",
-   "metadata": {},
-   "source": [
-    "Pour ajouter deux colonnes (ou plus), on peut les ajouter une par une (attention toutes les colonnes doivent avoir la même longueur, sinon une erreur se produira). "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "id": "ede5412c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:35.544800Z",
-     "start_time": "2024-10-01T09:10:35.533856Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Number of petals</th>\n",
-       "      <th>Name</th>\n",
-       "      <th>Color</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>8</td>\n",
-       "      <td>lotus</td>\n",
-       "      <td>pink</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>34</td>\n",
-       "      <td>sunflower</td>\n",
-       "      <td>yellow</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5</td>\n",
-       "      <td>rose</td>\n",
-       "      <td>red</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Number of petals       Name   Color\n",
-       "0                 8      lotus    pink\n",
-       "1                34  sunflower  yellow\n",
-       "2                 5       rose     red"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "flowers = pandas.DataFrame()\n",
-    "flowers['Number of petals'] = [8, 34, 5]\n",
-    "flowers['Name'] = ['lotus', 'sunflower', 'rose']\n",
-    "flowers['Color'] = ['pink', 'yellow', 'red']\n",
-    "\n",
-    "flowers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "925eb8be",
-   "metadata": {},
-   "source": [
-    "Nous pouvons aussi créer un tableau directement en spécifiant les noms des colonnes comme clés d'un [dictionnaire python](https://www.w3schools.com/PYTHON/python_dictionaries.asp) avec comme valeurs associé à chaque clé, la liste des valeurs souhaitée dans la colonne correspondante. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "id": "d9bb68fb",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:37.063446Z",
-     "start_time": "2024-10-01T09:10:37.052596Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Number of petals</th>\n",
-       "      <th>Name</th>\n",
-       "      <th>Color</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>8</td>\n",
-       "      <td>lotus</td>\n",
-       "      <td>pink</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>34</td>\n",
-       "      <td>sunflower</td>\n",
-       "      <td>yellow</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5</td>\n",
-       "      <td>rose</td>\n",
-       "      <td>red</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Number of petals       Name   Color\n",
-       "0                 8      lotus    pink\n",
-       "1                34  sunflower  yellow\n",
-       "2                 5       rose     red"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "\n",
-    "flowers_dict = {'Number of petals' : [8, 34, 5],\n",
-    "                'Name' : ['lotus', 'sunflower', 'rose'],\n",
-    "                'Color' : ['pink', 'yellow', 'red']\n",
-    "}\n",
-    "\n",
-    "flowers = pandas.DataFrame(flowers_dict)\n",
-    "flowers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d5e1a263",
-   "metadata": {},
-   "source": [
-    "La création de tableaux de cette manière implique beaucoup de saisie. Si les données ont déjà été saisies quelque part, il est généralement possible d'utiliser Python pour les lire dans un tableau, au lieu de les saisir cellule par cellule.\n",
-    "\n",
-    "Souvent, les tableaux sont créés à partir de fichiers contenant des valeurs séparées par des virgules. Ces fichiers sont appelés fichiers CSV.\n",
-    "\n",
-    "Ci-dessous, nous utilisons la méthode Table `read_csv` de la librairie pandas pour lire un fichier CSV qui contient certaines des données utilisées par Minard dans son graphique sur la campagne russe de Napoléon. Les données sont placées dans une table nommée `minard`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "5825f203",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:38.021443Z",
-     "start_time": "2024-10-01T09:10:38.012483Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude         City Direction  Survivors\n",
-       "0       32.0      54.8     Smolensk   Advance     145000\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
-       "2       34.4      55.5        Chjat   Advance     127100\n",
-       "3       37.6      55.8       Moscou   Advance     100000\n",
-       "4       34.3      55.2        Wixma   Retreat      55000\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000\n",
-       "6       30.4      54.4       Orscha   Retreat      20000\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard = pandas.read_csv(path_data + 'minard.csv')\n",
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c945f439",
-   "metadata": {},
-   "source": [
-    "Nous utiliserons ce petit tableau pour démontrer certaines méthodes utiles. Nous utiliserons ensuite ces mêmes méthodes, et en développerons d'autres, sur des tableaux de données beaucoup plus importants."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9af7fc2c",
-   "metadata": {},
-   "source": [
-    "#### La taille de la table\n",
-    "\n",
-    "La méthode `len` appliquée à l'attribut `columns` d'un tableau donne le nombre de colonnes du tableau, et `len` appliqué directement au tableau lui-même donne le nombre de lignes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "id": "fb2f8ac6",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:39.329181Z",
-     "start_time": "2024-10-01T09:10:39.324512Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5"
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(minard.columns)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "id": "5779c3c0",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:40.376490Z",
-     "start_time": "2024-10-01T09:10:40.372225Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "8"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(minard)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "159574bc",
-   "metadata": {},
-   "source": [
-    "#### Étiquettes des colonnes\n",
-    "\n",
-    "La méthode `columns` peut être utilisée pour lister les étiquettes de toutes les colonnes. Avec `minard`, cela ne nous apporte pas grand chose, mais cela peut être très utile pour les tableaux qui sont si grands que toutes les colonnes ne sont pas visibles à l'écran."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "id": "f623f9c2",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:41.403427Z",
-     "start_time": "2024-10-01T09:10:41.399581Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['Longitude', 'Latitude', 'City', 'Direction', 'Survivors'], dtype='object')"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.columns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42d5e377",
-   "metadata": {},
-   "source": [
-    "Nous pouvons changer les étiquettes des colonnes en utilisant la méthode `relabeled`. Cette méthode crée une nouvelle table et laisse `minard` inchangé."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "id": "d8c37299",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:41.956951Z",
-     "start_time": "2024-10-01T09:10:41.949224Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude    City Name Direction  Survivors\n",
-       "0       32.0      54.8     Smolensk   Advance     145000\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
-       "2       34.4      55.5        Chjat   Advance     127100\n",
-       "3       37.6      55.8       Moscou   Advance     100000\n",
-       "4       34.3      55.2        Wixma   Retreat      55000\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000\n",
-       "6       30.4      54.4       Orscha   Retreat      20000\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.rename(columns={'City': 'City Name'})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a5baf6f6",
-   "metadata": {},
-   "source": [
-    "Toutefois, cette méthode ne modifie pas le tableau original."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "id": "2aee95b5",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:42.638754Z",
-     "start_time": "2024-10-01T09:10:42.629880Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude         City Direction  Survivors\n",
-       "0       32.0      54.8     Smolensk   Advance     145000\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
-       "2       34.4      55.5        Chjat   Advance     127100\n",
-       "3       37.6      55.8       Moscou   Advance     100000\n",
-       "4       34.3      55.2        Wixma   Retreat      55000\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000\n",
-       "6       30.4      54.4       Orscha   Retreat      20000\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000"
-      ]
-     },
-     "execution_count": 41,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "196e6c8b",
-   "metadata": {},
-   "source": [
-    "Il est courant d'attribuer le nom original `minard` à la nouvelle table, de sorte que toutes les utilisations futures de `minard` fassent référence à la table réétiquetée."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "id": "53986932",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:43.450883Z",
-     "start_time": "2024-10-01T09:10:43.441717Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude    City Name Direction  Survivors\n",
-       "0       32.0      54.8     Smolensk   Advance     145000\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000\n",
-       "2       34.4      55.5        Chjat   Advance     127100\n",
-       "3       37.6      55.8       Moscou   Advance     100000\n",
-       "4       34.3      55.2        Wixma   Retreat      55000\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000\n",
-       "6       30.4      54.4       Orscha   Retreat      20000\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000"
-      ]
-     },
-     "execution_count": 42,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard = minard.rename(columns={'City': 'City Name'})\n",
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "29a817fb",
    "metadata": {
     "jp-MarkdownHeadingCollapsed": true
    },
    "source": [
-    "#### Accéder aux données d'une colonne\n",
-    "\n",
-    "Nous pouvons utiliser l'étiquette d'une colonne pour accéder au tableau de données qu'elle contient."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "id": "e4c4b2e4",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:44.797680Z",
-     "start_time": "2024-10-01T09:10:44.793725Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    145000\n",
-       "1    140000\n",
-       "2    127100\n",
-       "3    100000\n",
-       "4     55000\n",
-       "5     24000\n",
-       "6     20000\n",
-       "7     12000\n",
-       "Name: Survivors, dtype: int64"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard['Survivors']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "73531310",
-   "metadata": {},
-   "source": [
-    "Les 5 colonnes sont indexées 0, 1, 2, 3 et 4. La colonne `Survivants` peut également être accédée en utilisant l'index de sa colonne (4). Pour cela, il faut utiliser l'attribut `iloc` qui permet d'utiliser le tableau pandas comme un tableau numpy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "id": "67949c8c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:45.771839Z",
-     "start_time": "2024-10-01T09:10:45.767559Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    145000\n",
-       "1    140000\n",
-       "2    127100\n",
-       "3    100000\n",
-       "4     55000\n",
-       "5     24000\n",
-       "6     20000\n",
-       "7     12000\n",
-       "Name: Survivors, dtype: int64"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.iloc[:,4]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a81e23a",
-   "metadata": {},
-   "source": [
-    "Les 8 éléments du tableau sont indexés 0, 1, 2, et ainsi de suite jusqu'à 7. On peut accéder aux éléments de la colonne en continuant d'utiliser `iloc`, comme pour tout tableau numpy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "id": "9857947b",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:47.210526Z",
-     "start_time": "2024-10-01T09:10:47.206184Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "np.int64(145000)"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.iloc[0,4]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "id": "d39b8a38",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:48.250514Z",
-     "start_time": "2024-10-01T09:10:48.247164Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "np.int64(145000)"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard['Survivors'][0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2e6003d4",
-   "metadata": {},
-   "source": [
-    "#### Travailler avec les données d'une colonne\n",
-    "\n",
-    "Les colonnes étant des tableaux, nous pouvons utiliser des opérations sur les tableaux pour découvrir de nouvelles informations. Par exemple, nous pouvons créer une nouvelle colonne contenant le pourcentage de tous les survivants dans chaque ville après Smolensk."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 47,
-   "id": "9b296449",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:48.941809Z",
-     "start_time": "2024-10-01T09:10:48.933872Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "      <th>Percent Surviving</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "      <td>1.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "      <td>0.965517</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "      <td>0.876552</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "      <td>0.689655</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "      <td>0.379310</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "      <td>0.165517</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "      <td>0.137931</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "      <td>0.082759</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude    City Name Direction  Survivors  Percent Surviving\n",
-       "0       32.0      54.8     Smolensk   Advance     145000           1.000000\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000           0.965517\n",
-       "2       34.4      55.5        Chjat   Advance     127100           0.876552\n",
-       "3       37.6      55.8       Moscou   Advance     100000           0.689655\n",
-       "4       34.3      55.2        Wixma   Retreat      55000           0.379310\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000           0.165517\n",
-       "6       30.4      54.4       Orscha   Retreat      20000           0.137931\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000           0.082759"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "initial = minard['Survivors'][0]\n",
-    "minard['Percent Surviving'] = minard['Survivors']/initial\n",
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d9ff9391",
-   "metadata": {},
-   "source": [
-    "Pour que les proportions dans les nouvelles colonnes apparaissent sous forme de pourcentages, nous pouvons utiliser la méthode `.style.format` avec le format `{:,.2%}`. Ici, les accolades et les deux points `{:}` sont obligatoires, le `.2` signifie que l'on veut garder deux chiffres après la virgule, et le `%` signifie que l'on veut un pourcentage. Les options de formatages sont disponibles sur ce lien (en anglais) [https://fstring.help/cheat/](https://fstring.help/cheat/)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 48,
-   "id": "bfd7e54f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:49.622164Z",
-     "start_time": "2024-10-01T09:10:49.610264Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "      <th>Percent Surviving</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "      <td>100.00%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "      <td>96.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "      <td>87.66%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "      <td>68.97%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "      <td>37.93%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "      <td>16.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "      <td>13.79%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "      <td>8.28%</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude    City Name Direction  Survivors Percent Surviving\n",
-       "0       32.0      54.8     Smolensk   Advance     145000           100.00%\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000            96.55%\n",
-       "2       34.4      55.5        Chjat   Advance     127100            87.66%\n",
-       "3       37.6      55.8       Moscou   Advance     100000            68.97%\n",
-       "4       34.3      55.2        Wixma   Retreat      55000            37.93%\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000            16.55%\n",
-       "6       30.4      54.4       Orscha   Retreat      20000            13.79%\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000             8.28%"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard['Percent Surviving'] = minard['Percent Surviving'].map('{:,.2%}'.format)\n",
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45264341",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
-   "source": [
-    "#### Choisir des ensembles de colonnes\n",
-    "\n",
-    "Pour créer une nouvelle table qui ne contient que les colonnes spécifiées, on peut utiliser une nouvelle liste Python."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "id": "dfdb894e",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:50.548043Z",
-     "start_time": "2024-10-01T09:10:50.537907Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude\n",
-       "0       32.0      54.8\n",
-       "1       33.2      54.9\n",
-       "2       34.4      55.5\n",
-       "3       37.6      55.8\n",
-       "4       34.3      55.2\n",
-       "5       32.0      54.6\n",
-       "6       30.4      54.4\n",
-       "7       26.8      54.3"
-      ]
-     },
-     "execution_count": 49,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard[['Longitude', 'Latitude']]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "416f5d81",
-   "metadata": {},
-   "source": [
-    "La même sélection peut être effectuée en utilisant des indices de colonne au lieu d'étiquettes à l'aide de la méthode `iloc`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "id": "0d814895",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:51.907598Z",
-     "start_time": "2024-10-01T09:10:51.900750Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude\n",
-       "0       32.0      54.8\n",
-       "1       33.2      54.9\n",
-       "2       34.4      55.5\n",
-       "3       37.6      55.8\n",
-       "4       34.3      55.2\n",
-       "5       32.0      54.6\n",
-       "6       30.4      54.4\n",
-       "7       26.8      54.3"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.iloc[:,[0, 1]]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1624aab7",
-   "metadata": {},
-   "source": [
-    "La sélection d'une colonne est un nouveau tableau, même si vous ne sélectionnez qu'une seule colonne."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "id": "92604851",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:52.822162Z",
-     "start_time": "2024-10-01T09:10:52.818510Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0    145000\n",
-       "1    140000\n",
-       "2    127100\n",
-       "3    100000\n",
-       "4     55000\n",
-       "5     24000\n",
-       "6     20000\n",
-       "7     12000\n",
-       "Name: Survivors, dtype: int64"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard['Survivors']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "24f42b73",
-   "metadata": {},
-   "source": [
-    "Une autre façon de créer une nouvelle table composée d'un ensemble de colonnes est de \"supprimer\" les colonnes dont vous ne voulez pas."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "id": "64a8fa99",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:53.937660Z",
-     "start_time": "2024-10-01T09:10:53.928165Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Survivors</th>\n",
-       "      <th>Percent Surviving</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>145000</td>\n",
-       "      <td>100.00%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>140000</td>\n",
-       "      <td>96.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>127100</td>\n",
-       "      <td>87.66%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>100000</td>\n",
-       "      <td>68.97%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>55000</td>\n",
-       "      <td>37.93%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>24000</td>\n",
-       "      <td>16.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>20000</td>\n",
-       "      <td>13.79%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>12000</td>\n",
-       "      <td>8.28%</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     City Name  Survivors Percent Surviving\n",
-       "0     Smolensk     145000           100.00%\n",
-       "1  Dorogobouge     140000            96.55%\n",
-       "2        Chjat     127100            87.66%\n",
-       "3       Moscou     100000            68.97%\n",
-       "4        Wixma      55000            37.93%\n",
-       "5     Smolensk      24000            16.55%\n",
-       "6       Orscha      20000            13.79%\n",
-       "7    Moiodexno      12000             8.28%"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard.drop(columns=['Longitude', 'Latitude', 'Direction'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5d7f22cc",
-   "metadata": {},
-   "source": [
-    "Ni la selection ni `drop` ne modifient la table d'origine. Au lieu de cela, ils créent de nouvelles tables plus petites qui partagent les mêmes données. Le fait que la table originale soit préservée est utile ! Vous pouvez générer plusieurs tableaux différents qui ne prennent en compte que certaines colonnes sans craindre qu'une analyse n'affecte l'autre."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "id": "28da3c59",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:55.353878Z",
-     "start_time": "2024-10-01T09:10:55.340941Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Longitude</th>\n",
-       "      <th>Latitude</th>\n",
-       "      <th>City Name</th>\n",
-       "      <th>Direction</th>\n",
-       "      <th>Survivors</th>\n",
-       "      <th>Percent Surviving</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.8</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>145000</td>\n",
-       "      <td>100.00%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>33.2</td>\n",
-       "      <td>54.9</td>\n",
-       "      <td>Dorogobouge</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>140000</td>\n",
-       "      <td>96.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>34.4</td>\n",
-       "      <td>55.5</td>\n",
-       "      <td>Chjat</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>127100</td>\n",
-       "      <td>87.66%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>37.6</td>\n",
-       "      <td>55.8</td>\n",
-       "      <td>Moscou</td>\n",
-       "      <td>Advance</td>\n",
-       "      <td>100000</td>\n",
-       "      <td>68.97%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>34.3</td>\n",
-       "      <td>55.2</td>\n",
-       "      <td>Wixma</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>55000</td>\n",
-       "      <td>37.93%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>32.0</td>\n",
-       "      <td>54.6</td>\n",
-       "      <td>Smolensk</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>24000</td>\n",
-       "      <td>16.55%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>30.4</td>\n",
-       "      <td>54.4</td>\n",
-       "      <td>Orscha</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>20000</td>\n",
-       "      <td>13.79%</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>26.8</td>\n",
-       "      <td>54.3</td>\n",
-       "      <td>Moiodexno</td>\n",
-       "      <td>Retreat</td>\n",
-       "      <td>12000</td>\n",
-       "      <td>8.28%</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Longitude  Latitude    City Name Direction  Survivors Percent Surviving\n",
-       "0       32.0      54.8     Smolensk   Advance     145000           100.00%\n",
-       "1       33.2      54.9  Dorogobouge   Advance     140000            96.55%\n",
-       "2       34.4      55.5        Chjat   Advance     127100            87.66%\n",
-       "3       37.6      55.8       Moscou   Advance     100000            68.97%\n",
-       "4       34.3      55.2        Wixma   Retreat      55000            37.93%\n",
-       "5       32.0      54.6     Smolensk   Retreat      24000            16.55%\n",
-       "6       30.4      54.4       Orscha   Retreat      20000            13.79%\n",
-       "7       26.8      54.3    Moiodexno   Retreat      12000             8.28%"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "minard"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "87fa4e16",
-   "metadata": {},
-   "source": [
-    "Toutes les méthodes que nous avons utilisées ci-dessus peuvent être appliquées à n'importe quel tableau."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8b65de58",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
-   "source": [
-    "#### Tri des lignes\n",
-    "\n",
-    "\"La NBA est la ligue sportive professionnelle la mieux payée au monde\", [a rapporté CNN](http://edition.cnn.com/2015/12/04/sport/gallery/highest-paid-nba-players/) en mars 2016. La table `nba_salaries` contient les salaires de tous les joueurs de la National Basketball Association en 2015-2016.\n",
-    "\n",
-    "Chaque ligne représente un joueur. Les colonnes sont :\n",
-    "\n",
-    "| Les colonnes sont les suivantes : - **Étiquette de la colonne** | Description\n",
-    "|--------------------|-----------------------------------------------------|\n",
-    "| `PLAYER` | Nom du joueur | `POSITION` | Position du joueur dans l'équipe\n",
-    "| `POSITION` | Position du joueur dans l'équipe | `TEAM` | Nom de l'équipe\n",
-    "| `TEAM` | Nom de l'équipe |\n",
-    "|``SALAIRE'15-'16` | Salaire du joueur en 2015-2016, en millions de dollars|\n",
-    " \n",
-    "Le code des postes est PG (Point Guard), SG (Shooting Guard), PF (Power Forward), SF (Small Forward) et C (Center). Mais ce qui suit n'implique pas de détails sur la façon dont le basket-ball est joué.\n",
-    "\n",
-    "La première ligne montre que Paul Millsap, attaquant des Atlanta Hawks, a perçu un salaire de près de 18,7 millions de dollars en 2015-2016."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "id": "bb9312cd",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:56.354170Z",
-     "start_time": "2024-10-01T09:10:56.346389Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>PLAYER</th>\n",
-       "      <th>POSITION</th>\n",
-       "      <th>TEAM</th>\n",
-       "      <th>'15-'16 SALARY</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Paul Millsap</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>18.671659</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Al Horford</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>12.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Tiago Splitter</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>9.756250</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Jeff Teague</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>8.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kyle Korver</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>5.746479</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>412</th>\n",
-       "      <td>Gary Neal</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Washington Wizards</td>\n",
-       "      <td>2.139000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>413</th>\n",
-       "      <td>DeJuan Blair</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Washington Wizards</td>\n",
-       "      <td>2.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>414</th>\n",
-       "      <td>Kelly Oubre Jr.</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Washington Wizards</td>\n",
-       "      <td>1.920240</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>415</th>\n",
-       "      <td>Garrett Temple</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Washington Wizards</td>\n",
-       "      <td>1.100602</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>416</th>\n",
-       "      <td>Jarell Eddie</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Washington Wizards</td>\n",
-       "      <td>0.561716</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>417 rows × 4 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "              PLAYER POSITION                TEAM  '15-'16 SALARY\n",
-       "0       Paul Millsap       PF       Atlanta Hawks       18.671659\n",
-       "1         Al Horford        C       Atlanta Hawks       12.000000\n",
-       "2     Tiago Splitter        C       Atlanta Hawks        9.756250\n",
-       "3        Jeff Teague       PG       Atlanta Hawks        8.000000\n",
-       "4        Kyle Korver       SG       Atlanta Hawks        5.746479\n",
-       "..               ...      ...                 ...             ...\n",
-       "412        Gary Neal       PG  Washington Wizards        2.139000\n",
-       "413     DeJuan Blair        C  Washington Wizards        2.000000\n",
-       "414  Kelly Oubre Jr.       SF  Washington Wizards        1.920240\n",
-       "415   Garrett Temple       SG  Washington Wizards        1.100602\n",
-       "416     Jarell Eddie       SG  Washington Wizards        0.561716\n",
-       "\n",
-       "[417 rows x 4 columns]"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# This table can be found online: https://www.statcrunch.com/app/index.php?dataid=1843341\n",
-    "nba_salaries = pandas.read_csv(path_data + 'nba_salaries.csv')\n",
-    "nba_salaries"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3f3a443f",
-   "metadata": {},
-   "source": [
-    "Le tableau contient 417 lignes, une pour chaque joueur. Seules 10 lignes sont affichées. La méthode `head` nous permet de spécifier le nombre de lignes, la valeur par défaut (aucune spécification) étant `5`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "id": "385a3c4d",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:57.416626Z",
-     "start_time": "2024-10-01T09:10:57.407119Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>PLAYER</th>\n",
-       "      <th>POSITION</th>\n",
-       "      <th>TEAM</th>\n",
-       "      <th>'15-'16 SALARY</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Paul Millsap</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>18.671659</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Al Horford</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>12.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Tiago Splitter</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>9.756250</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>Jeff Teague</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>8.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>Kyle Korver</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>5.746479</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "           PLAYER POSITION           TEAM  '15-'16 SALARY\n",
-       "0    Paul Millsap       PF  Atlanta Hawks       18.671659\n",
-       "1      Al Horford        C  Atlanta Hawks       12.000000\n",
-       "2  Tiago Splitter        C  Atlanta Hawks        9.756250\n",
-       "3     Jeff Teague       PG  Atlanta Hawks        8.000000\n",
-       "4     Kyle Korver       SG  Atlanta Hawks        5.746479"
-      ]
-     },
-     "execution_count": 55,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "nba_salaries.head(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce3229d8",
-   "metadata": {},
-   "source": [
-    "Parcourez une vingtaine de lignes et vous verrez qu'elles sont classées par ordre alphabétique du nom de l'équipe. Il est également possible de lister les mêmes lignes dans l'ordre alphabétique des noms de joueurs en utilisant la méthode `sort_values`. L'argument de `sort_values` est un libellé de colonne ou un index."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 56,
-   "id": "049afec3",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:58.676191Z",
-     "start_time": "2024-10-01T09:10:58.668041Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>PLAYER</th>\n",
-       "      <th>POSITION</th>\n",
-       "      <th>TEAM</th>\n",
-       "      <th>'15-'16 SALARY</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>68</th>\n",
-       "      <td>Aaron Brooks</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Chicago Bulls</td>\n",
-       "      <td>2.250000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>291</th>\n",
-       "      <td>Aaron Gordon</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Orlando Magic</td>\n",
-       "      <td>4.171680</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>59</th>\n",
-       "      <td>Aaron Harrison</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Charlotte Hornets</td>\n",
-       "      <td>0.525093</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>235</th>\n",
-       "      <td>Adreian Payne</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Minnesota Timberwolves</td>\n",
-       "      <td>1.938840</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Al Horford</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Atlanta Hawks</td>\n",
-       "      <td>12.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "             PLAYER POSITION                    TEAM  '15-'16 SALARY\n",
-       "68     Aaron Brooks       PG           Chicago Bulls        2.250000\n",
-       "291    Aaron Gordon       PF           Orlando Magic        4.171680\n",
-       "59   Aaron Harrison       SG       Charlotte Hornets        0.525093\n",
-       "235   Adreian Payne       PF  Minnesota Timberwolves        1.938840\n",
-       "1        Al Horford        C           Atlanta Hawks       12.000000"
-      ]
-     },
-     "execution_count": 56,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "nba_salaries.sort_values('PLAYER').head(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2a97043d",
-   "metadata": {},
-   "source": [
-    "Pour examiner les salaires des joueurs, il serait beaucoup plus utile que les données soient classées par salaire.\n",
-    "\n",
-    "Pour ce faire, nous allons d'abord simplifier le libellé de la colonne des salaires (pour des raisons de commodité), puis trier les données en fonction du nouveau libellé \"SALARY\".\n",
-    "\n",
-    "Cela permet de classer toutes les lignes du tableau par ordre *croissant* de salaire, le salaire le plus bas apparaissant en premier. Le résultat est un nouveau tableau avec les mêmes colonnes que l'original mais avec les lignes réarrangées."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 57,
-   "id": "505f068c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:10:59.878291Z",
-     "start_time": "2024-10-01T09:10:59.868121Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>PLAYER</th>\n",
-       "      <th>POSITION</th>\n",
-       "      <th>TEAM</th>\n",
-       "      <th>SALARY</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>267</th>\n",
-       "      <td>Thanasis Antetokounmpo</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>New York Knicks</td>\n",
-       "      <td>0.030888</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>326</th>\n",
-       "      <td>Jordan McRae</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.049709</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>327</th>\n",
-       "      <td>Cory Jefferson</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.049709</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>324</th>\n",
-       "      <td>Orlando Johnson</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.055722</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>325</th>\n",
-       "      <td>Phil Pressey</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.055722</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>131</th>\n",
-       "      <td>Dwight Howard</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Houston Rockets</td>\n",
-       "      <td>22.359364</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255</th>\n",
-       "      <td>Carmelo Anthony</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>New York Knicks</td>\n",
-       "      <td>22.875000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72</th>\n",
-       "      <td>LeBron James</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Cleveland Cavaliers</td>\n",
-       "      <td>22.970500</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>Joe Johnson</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Brooklyn Nets</td>\n",
-       "      <td>24.894863</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>169</th>\n",
-       "      <td>Kobe Bryant</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Los Angeles Lakers</td>\n",
-       "      <td>25.000000</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>417 rows × 4 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     PLAYER POSITION                 TEAM     SALARY\n",
-       "267  Thanasis Antetokounmpo       SF      New York Knicks   0.030888\n",
-       "326            Jordan McRae       SG         Phoenix Suns   0.049709\n",
-       "327          Cory Jefferson       PF         Phoenix Suns   0.049709\n",
-       "324         Orlando Johnson       SG         Phoenix Suns   0.055722\n",
-       "325            Phil Pressey       PG         Phoenix Suns   0.055722\n",
-       "..                      ...      ...                  ...        ...\n",
-       "131           Dwight Howard        C      Houston Rockets  22.359364\n",
-       "255         Carmelo Anthony       SF      New York Knicks  22.875000\n",
-       "72             LeBron James       SF  Cleveland Cavaliers  22.970500\n",
-       "29              Joe Johnson       SF        Brooklyn Nets  24.894863\n",
-       "169             Kobe Bryant       SF   Los Angeles Lakers  25.000000\n",
-       "\n",
-       "[417 rows x 4 columns]"
-      ]
-     },
-     "execution_count": 57,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "nba = nba_salaries.rename(columns={\"'15-'16 SALARY\": 'SALARY'})\n",
-    "nba.sort_values('SALARY')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "af226f54",
-   "metadata": {},
-   "source": [
-    "Ces chiffres sont quelque peu difficiles à comparer car certains de ces joueurs ont changé d'équipe au cours de la saison et ont reçu des salaires de plus d'une équipe ; seul le salaire de la dernière équipe apparaît dans le tableau. Le meneur de jeu Phil Pressey, par exemple, est passé de Philadelphie à Phoenix au cours de l'année, et pourrait encore changer d'équipe pour rejoindre les Golden State Warriors.\n",
-    "\n",
-    "Le rapport de CNN porte sur l'autre extrémité de l'échelle des salaires, à savoir les joueurs qui figurent parmi les mieux payés au monde.\n",
-    "\n",
-    "Pour classer les lignes du tableau par ordre *décroissant* de salaire, nous devons utiliser `sort_values` avec l'option `ascending=False`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 58,
-   "id": "b0c4f060",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-01T09:11:01.080925Z",
-     "start_time": "2024-10-01T09:11:01.070017Z"
-    },
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>PLAYER</th>\n",
-       "      <th>POSITION</th>\n",
-       "      <th>TEAM</th>\n",
-       "      <th>SALARY</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>169</th>\n",
-       "      <td>Kobe Bryant</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Los Angeles Lakers</td>\n",
-       "      <td>25.000000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>29</th>\n",
-       "      <td>Joe Johnson</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Brooklyn Nets</td>\n",
-       "      <td>24.894863</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>72</th>\n",
-       "      <td>LeBron James</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>Cleveland Cavaliers</td>\n",
-       "      <td>22.970500</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>255</th>\n",
-       "      <td>Carmelo Anthony</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>New York Knicks</td>\n",
-       "      <td>22.875000</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>131</th>\n",
-       "      <td>Dwight Howard</td>\n",
-       "      <td>C</td>\n",
-       "      <td>Houston Rockets</td>\n",
-       "      <td>22.359364</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>325</th>\n",
-       "      <td>Phil Pressey</td>\n",
-       "      <td>PG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.055722</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>324</th>\n",
-       "      <td>Orlando Johnson</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.055722</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>326</th>\n",
-       "      <td>Jordan McRae</td>\n",
-       "      <td>SG</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.049709</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>327</th>\n",
-       "      <td>Cory Jefferson</td>\n",
-       "      <td>PF</td>\n",
-       "      <td>Phoenix Suns</td>\n",
-       "      <td>0.049709</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>267</th>\n",
-       "      <td>Thanasis Antetokounmpo</td>\n",
-       "      <td>SF</td>\n",
-       "      <td>New York Knicks</td>\n",
-       "      <td>0.030888</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>417 rows × 4 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     PLAYER POSITION                 TEAM     SALARY\n",
-       "169             Kobe Bryant       SF   Los Angeles Lakers  25.000000\n",
-       "29              Joe Johnson       SF        Brooklyn Nets  24.894863\n",
-       "72             LeBron James       SF  Cleveland Cavaliers  22.970500\n",
-       "255         Carmelo Anthony       SF      New York Knicks  22.875000\n",
-       "131           Dwight Howard        C      Houston Rockets  22.359364\n",
-       "..                      ...      ...                  ...        ...\n",
-       "325            Phil Pressey       PG         Phoenix Suns   0.055722\n",
-       "324         Orlando Johnson       SG         Phoenix Suns   0.055722\n",
-       "326            Jordan McRae       SG         Phoenix Suns   0.049709\n",
-       "327          Cory Jefferson       PF         Phoenix Suns   0.049709\n",
-       "267  Thanasis Antetokounmpo       SF      New York Knicks   0.030888\n",
-       "\n",
-       "[417 rows x 4 columns]"
-      ]
-     },
-     "execution_count": 58,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "nba.sort_values('SALARY', ascending=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1505b846",
-   "metadata": {},
-   "source": [
-    "Kobe Bryant, lors de sa dernière saison avec les Lakers, a été le mieux payé avec un salaire de 25 millions de dollars. On notera que le MVP Stephen Curry n'apparaît pas dans le top 10. Il est bien plus loin dans la liste, comme nous le verrons plus tard."
+    "Kobe Bryant, lors de sa dernière saison avec les Lakers, a été le mieux payé avec un salaire de 25 millions de dollars. On notera que le MVP Stephen Curry n'apparaît pas dans le top 10. Il est bien plus loin dans la liste, comme nous l'avons vu plus haut."
    ]
   },
   {
@@ -5737,15 +5084,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 55,
    "id": "e25fe7e8",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:02.469751Z",
      "start_time": "2024-10-01T09:11:02.465199Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -5941,15 +5285,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 56,
    "id": "8d15a70b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:03.384010Z",
      "start_time": "2024-10-01T09:11:03.375167Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6080,7 +5421,7 @@
        "[417 rows x 4 columns]"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6091,15 +5432,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 57,
    "id": "3fd52189",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:04.287088Z",
      "start_time": "2024-10-01T09:11:04.276014Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6147,7 +5485,7 @@
        "0  Paul Millsap       PF  Atlanta Hawks  18.671659"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6168,15 +5506,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 58,
    "id": "7a48d048",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:05.213690Z",
      "start_time": "2024-10-01T09:11:05.203828Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6240,7 +5575,7 @@
        "5  Thabo Sefolosha       SF  Atlanta Hawks  4.000000"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6259,15 +5594,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 59,
    "id": "56735121",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:06.408061Z",
      "start_time": "2024-10-01T09:11:06.400144Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6347,7 +5679,7 @@
        "131    Dwight Howard        C      Houston Rockets  22.359364"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6359,9 +5691,7 @@
   {
    "cell_type": "markdown",
    "id": "83b2ed2b",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Lignes correspondant à une caractéristique spécifiée\n",
     "Le plus souvent, nous souhaitons accéder aux données d'un ensemble de lignes présentant une certaine caractéristique, mais dont nous ne connaissons pas les indices à l'avance. Par exemple, nous pourrions vouloir obtenir des données sur tous les joueurs qui ont gagné plus de 10 millions de dollars, mais nous ne voulons pas perdre de temps à compter les lignes dans le tableau trié.\n",
@@ -6373,15 +5703,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 60,
    "id": "828fe7ce",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:07.491816Z",
      "start_time": "2024-10-01T09:11:07.480564Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6512,7 +5839,7 @@
        "[69 rows x 4 columns]"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6531,15 +5858,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 61,
    "id": "f0967fab",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:09.020351Z",
      "start_time": "2024-10-01T09:11:09.008435Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6670,7 +5994,7 @@
        "[69 rows x 4 columns]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6689,15 +6013,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 62,
    "id": "389651ac",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:09.881656Z",
      "start_time": "2024-10-01T09:11:09.875407Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6745,7 +6066,7 @@
        "121  Stephen Curry       PG  Golden State Warriors  11.370786"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6764,15 +6085,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 63,
    "id": "20069c07",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:10.886812Z",
      "start_time": "2024-10-01T09:11:10.879674Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6813,9 +6131,7 @@
   {
    "cell_type": "markdown",
    "id": "ca1b5f6f",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Caractéristiques multiples\n",
     "Vous pouvez accéder à des lignes qui ont plusieurs caractéristiques spécifiées, en combinant les opérateurs logiques à l'aide de `&`. Par exemple, voici un moyen d'extraire tous les gardes dont le salaire est supérieur à 15 millions de dollars."
@@ -6823,15 +6139,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 64,
    "id": "3eae7369",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:12.193701Z",
      "start_time": "2024-10-01T09:11:12.182131Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -6911,7 +6224,7 @@
        "400          John Wall       PG     Washington Wizards  15.851950"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6923,9 +6236,7 @@
   {
    "cell_type": "markdown",
    "id": "ad52f0e4",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Forme générale\n",
     "Vous avez maintenant compris que la façon générale de créer une nouvelle table en sélectionnant les lignes ayant une caractéristique donnée est d'utiliser la condition appropriée :\n",
@@ -6935,15 +6246,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 65,
    "id": "f500a71d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:13.239993Z",
      "start_time": "2024-10-01T09:11:13.231341Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7015,7 +6323,7 @@
        "368   DeMar DeRozan       SG     Toronto Raptors  10.050000"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7042,15 +6350,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 66,
    "id": "e3296f0f",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:11:13.915411Z",
      "start_time": "2024-10-01T09:11:13.910101Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7092,7 +6397,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7164,15 +6469,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 67,
    "id": "d4b3b0f6",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:16:16.474880Z",
      "start_time": "2024-10-01T09:16:16.467336Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7324,7 +6626,7 @@
        "130   Anderson Varejao       PF  Golden State Warriors   0.289755"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7343,15 +6645,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 68,
    "id": "c072b83d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:26:01.783270Z",
      "start_time": "2024-10-01T09:26:01.775953Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7482,7 +6781,7 @@
        "[181 rows x 4 columns]"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7501,15 +6800,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 69,
    "id": "463897b8",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:27:34.132485Z",
      "start_time": "2024-10-01T09:27:34.123680Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7621,7 +6917,7 @@
        "268     Kevin Durant       SF  Oklahoma City Thunder  20.158622"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7641,15 +6937,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 70,
    "id": "c3b35723",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:27:56.219276Z",
      "start_time": "2024-10-01T09:27:56.212374Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7761,7 +7054,7 @@
        "268     Kevin Durant       SF  Oklahoma City Thunder  20.158622"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7808,15 +7101,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 71,
    "id": "2b0dc77a",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T09:28:44.711109Z",
      "start_time": "2024-10-01T09:28:44.708447Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [],
@@ -7850,15 +7140,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 72,
    "id": "14bdc85d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T10:34:59.088210Z",
      "start_time": "2024-10-01T10:34:59.084711Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7868,7 +7155,7 @@
        "34"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7879,15 +7166,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 73,
    "id": "a7f3d8a7",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T10:35:00.916261Z",
      "start_time": "2024-10-01T10:35:00.913293Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7897,7 +7181,7 @@
        "-0.3"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7924,15 +7208,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 74,
    "id": "514afea1",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:34:16.205151Z",
      "start_time": "2024-10-01T11:34:16.202159Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -7942,7 +7223,7 @@
        "84"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7962,7 +7243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 75,
    "id": "55d57d96",
    "metadata": {
     "ExecuteTime": {
@@ -7977,7 +7258,7 @@
        "array([ 6,  8, 10])"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 75,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7998,12 +7279,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 76,
    "id": "eff66b41",
    "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    },
     "tags": [
      "raises-exception"
     ]
@@ -8016,7 +7294,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[80], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mx\u001b[49m\n",
+      "Cell \u001b[0;32mIn[76], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mx\u001b[49m\n",
       "\u001b[0;31mNameError\u001b[0m: name 'x' is not defined"
      ]
     }
@@ -8039,15 +7317,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 77,
    "id": "7cd43b77",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:35:48.780381Z",
      "start_time": "2024-10-01T11:35:48.777342Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [],
@@ -8071,15 +7346,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 78,
    "id": "7d03b16b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:35:50.708915Z",
      "start_time": "2024-10-01T11:35:50.705693Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8089,7 +7361,7 @@
        "16.5"
       ]
      },
-     "execution_count": 82,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8108,15 +7380,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 79,
    "id": "b89804f3",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:36:19.357568Z",
      "start_time": "2024-10-01T11:36:19.355332Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [],
@@ -8137,7 +7406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 80,
    "id": "ed335175",
    "metadata": {
     "ExecuteTime": {
@@ -8152,7 +7421,7 @@
        "array([33.33, 47.62, 19.05])"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8172,7 +7441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 81,
    "id": "77850d95",
    "metadata": {
     "ExecuteTime": {
@@ -8229,7 +7498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 82,
    "id": "0a608272",
    "metadata": {
     "ExecuteTime": {
@@ -8270,7 +7539,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 83,
    "id": "70d18e13",
    "metadata": {
     "ExecuteTime": {
@@ -8321,15 +7590,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 84,
    "id": "1ef9dc4e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:39:12.319744Z",
      "start_time": "2024-10-01T11:39:12.317524Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [],
@@ -8341,15 +7607,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 85,
    "id": "3d577334",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:39:13.764904Z",
      "start_time": "2024-10-01T11:39:13.760546Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8359,7 +7622,7 @@
        "17"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8370,15 +7633,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 86,
    "id": "0d2b626b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:39:15.356849Z",
      "start_time": "2024-10-01T11:39:15.352332Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8388,7 +7648,7 @@
        "100"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8399,15 +7659,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 87,
    "id": "c987f695",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:39:17.793584Z",
      "start_time": "2024-10-01T11:39:17.789016Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8417,7 +7674,7 @@
        "100"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8448,7 +7705,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 88,
    "id": "87197775",
    "metadata": {
     "ExecuteTime": {
@@ -8527,7 +7784,7 @@
        "5      F  101"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8543,9 +7800,7 @@
   {
    "cell_type": "markdown",
    "id": "18a16a94",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### `apply`\n",
     "\n",
@@ -8554,15 +7809,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 89,
    "id": "03ed662e",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:44:26.289402Z",
      "start_time": "2024-10-01T11:44:26.285223Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8578,7 +7830,7 @@
        "Name: Age, dtype: int64"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8599,15 +7851,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 90,
    "id": "1bb53945",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:45:26.309613Z",
      "start_time": "2024-10-01T11:45:26.300936Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8688,7 +7937,7 @@
        "5      F  101          100"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8701,9 +7950,7 @@
   {
    "cell_type": "markdown",
    "id": "5556bd86",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "#### Les fonctions en tant que valeurs\n",
     "Nous avons vu que Python possède de nombreux types de valeurs.  Par exemple, `6` est une valeur numérique, `\"cake\"` est une valeur textuelle, `pandas.DataFrame()` est une tableau vide, et `ages` est un nom pour un tableau (puisque nous l'avons défini plus haut).\n",
@@ -8715,15 +7962,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 91,
    "id": "7f37d911",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:47:16.708991Z",
      "start_time": "2024-10-01T11:47:16.703176Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8733,7 +7977,7 @@
        "<function __main__.cut_off_at_100(x)>"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8754,15 +7998,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 92,
    "id": "0d7662ef",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:47:34.313960Z",
      "start_time": "2024-10-01T11:47:34.311395Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [],
@@ -8780,15 +8021,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 93,
    "id": "679fcda9",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-10-01T11:47:43.667189Z",
      "start_time": "2024-10-01T11:47:43.663516Z"
-    },
-    "jupyter": {
-     "source_hidden": true
     }
    },
    "outputs": [
@@ -8798,7 +8036,7 @@
        "<function __main__.cut_off_at_100(x)>"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 93,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8824,12 +8062,12 @@
     "\n",
     "La science des données est souvent utilisée pour faire des prédictions sur l'avenir. Si nous essayons de prédire un résultat pour un individu particulier - par exemple, comment il réagira à un traitement ou s'il achètera un produit - il est naturel de baser la prédiction sur les résultats d'autres individus similaires.\n",
     "\n",
-    "Le tableau ci-dessous est adapté d'un ensemble de données historiques sur le poids des parents et de leurs enfants adultes. Chaque ligne correspond à un enfant adulte. Les variables sont un code numérique pour la famille, les tailles (en pouces) du père et de la mère, le nombre d'enfants dans la famille, ainsi que le rang de naissance de l'enfant (1 = le plus âgé), son sexe (codé uniquement comme \"homme\" ou \"femme\") et sa taille en pouces."
+    "Le tableau ci-dessous est adapté d'un ensemble de données historiques de Galton sur le poids des parents et de leurs enfants adultes. Chaque ligne correspond à un enfant adulte. Les variables sont un code numérique pour la famille, les tailles (en pouces) du père et de la mère, le nombre d'enfants dans la famille, ainsi que le rang de naissance de l'enfant (1 = le plus âgé), son sexe (codé uniquement comme \"homme\" ou \"femme\") et sa taille en pouces."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 94,
    "id": "9e6e1fb6",
    "metadata": {
     "ExecuteTime": {
@@ -9001,7 +8239,7 @@
        "[934 rows x 7 columns]"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9022,7 +8260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 95,
    "id": "88162206-095a-4047-867e-c468056fb6e0",
    "metadata": {},
    "outputs": [
@@ -9189,7 +8427,7 @@
        "[934 rows x 7 columns]"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9218,7 +8456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 96,
    "id": "2b345060",
    "metadata": {
     "editable": true,
@@ -9331,7 +8569,7 @@
        "[934 rows x 2 columns]"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9347,7 +8585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 97,
    "id": "f46b5131",
    "metadata": {},
    "outputs": [
@@ -9384,7 +8622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 98,
    "id": "e2fbc369",
    "metadata": {},
    "outputs": [
@@ -9416,7 +8654,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 99,
    "id": "e1da8b77",
    "metadata": {},
    "outputs": [
@@ -9523,7 +8761,7 @@
        "[155 rows x 2 columns]"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9543,7 +8781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 100,
    "id": "dd9c0749",
    "metadata": {},
    "outputs": [
@@ -9553,7 +8791,7 @@
        "np.float64(169.76540645161293)"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9572,7 +8810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 101,
    "id": "691671fe",
    "metadata": {},
    "outputs": [],
@@ -9598,7 +8836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 102,
    "id": "23a368ac",
    "metadata": {},
    "outputs": [
@@ -9608,7 +8846,7 @@
        "np.float64(169.76540645161293)"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9619,7 +8857,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 103,
    "id": "54415d7b",
    "metadata": {},
    "outputs": [
@@ -9629,7 +8867,7 @@
        "np.float64(167.6630909090909)"
       ]
      },
-     "execution_count": 107,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9648,7 +8886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 104,
    "id": "f8f40fe2",
    "metadata": {},
    "outputs": [
@@ -9767,7 +9005,7 @@
        "[934 rows x 3 columns]"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9789,7 +9027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 105,
    "id": "347c73b2",
    "metadata": {},
    "outputs": [
@@ -9820,7 +9058,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 106,
    "id": "9f8a47fe",
    "metadata": {},
    "outputs": [
@@ -9830,7 +9068,7 @@
        "np.float64(165.55357142857142)"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9846,7 +9084,7 @@
    "source": [
     "Remarquez que le graphique des moyennes suit approximativement une ligne droite. Cette ligne droite est désormais appelée \"ligne de régression\" et constitue l'une des méthodes les plus courantes pour faire des prédictions. Le calcul que nous venons de faire est très similaire à celui qui a conduit au développement de la méthode de régression, en utilisant les mêmes données.\n",
     "\n",
-    "Cet exemple, comme celui de l'analyse des décès dus au choléra par John Snow, montre que certains des concepts fondamentaux de la science moderne des données ont des racines très anciennes. La méthode utilisée ici était un précurseur des méthodes de prédiction du *voisin le plus proche*, qui trouvent aujourd'hui de puissantes applications dans divers domaines. Le domaine moderne de l'\"apprentissage automatique\" comprend l'automatisation de ces méthodes pour faire des prédictions basées sur des ensembles de données vastes et en évolution rapide."
+    "Cet exemple, montre que certains des concepts fondamentaux de la science moderne des données ont des racines très anciennes. La méthode utilisée ici était un précurseur des méthodes de prédiction du *voisin le plus proche*, qui trouvent aujourd'hui de puissantes applications dans divers domaines. Le domaine moderne de l'\"apprentissage automatique\" comprend l'automatisation de ces méthodes pour faire des prédictions basées sur des ensembles de données vastes et en évolution rapide."
    ]
   },
   {
@@ -9884,7 +9122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 107,
    "id": "07e83a7d",
    "metadata": {},
    "outputs": [
@@ -9952,7 +9190,7 @@
        "4   chocolate   5.25"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9975,17 +9213,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 108,
    "id": "b470316b-b977-47c8-8cc3-3b506362b290",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<pandas.core.groupby.generic.DataFrameGroupBy object at 0x7d121cb35df0>"
+       "<pandas.core.groupby.generic.DataFrameGroupBy object at 0x79743447c2c0>"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9996,7 +9234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 109,
    "id": "8629704b",
    "metadata": {},
    "outputs": [
@@ -10048,7 +9286,7 @@
        "strawberry      2"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10088,7 +9326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 110,
    "id": "6e90adb7",
    "metadata": {},
    "outputs": [
@@ -10140,7 +9378,7 @@
        "strawberry       8.80"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10159,7 +9397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 111,
    "id": "1a68efb2-0837-452e-b5bf-801af2d4b091",
    "metadata": {},
    "outputs": [
@@ -10215,7 +9453,7 @@
        "strawberry      2       8.80"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 111,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10238,7 +9476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 112,
    "id": "72866f21",
    "metadata": {},
    "outputs": [
@@ -10251,7 +9489,7 @@
        "Name: Price, dtype: float64"
       ]
      },
-     "execution_count": 116,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10262,7 +9500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 113,
    "id": "f2eadd6a",
    "metadata": {},
    "outputs": [
@@ -10272,7 +9510,7 @@
        "16.55"
       ]
      },
-     "execution_count": 117,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10291,7 +9529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 114,
    "id": "977cc219",
    "metadata": {},
    "outputs": [
@@ -10344,7 +9582,7 @@
        "1  strawberry            [3.55, 5.25]              8.80"
       ]
      },
-     "execution_count": 118,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10379,7 +9617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 115,
    "id": "720a3fd0-b26b-4711-a533-3fce7bc3d299",
    "metadata": {},
    "outputs": [
@@ -10429,7 +9667,7 @@
        "1  strawberry            [3.55, 5.25]"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10448,7 +9686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 116,
    "id": "ba5e2c0d",
    "metadata": {},
    "outputs": [
@@ -10500,7 +9738,7 @@
        "strawberry       5.25"
       ]
      },
-     "execution_count": 120,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10519,7 +9757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 117,
    "id": "a94caeb9",
    "metadata": {},
    "outputs": [
@@ -10572,7 +9810,7 @@
        "1  strawberry            [3.55, 5.25]              5.25"
       ]
      },
-     "execution_count": 121,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10591,7 +9829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 118,
    "id": "66e7eec4",
    "metadata": {},
    "outputs": [
@@ -10644,7 +9882,7 @@
        "1  strawberry            [3.55, 5.25]                    2"
       ]
      },
-     "execution_count": 122,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10664,7 +9902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 119,
    "id": "e2a1d7ed",
    "metadata": {},
    "outputs": [
@@ -10795,7 +10033,7 @@
        "[417 rows x 4 columns]"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 119,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10818,7 +10056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 120,
    "id": "49b108e1",
    "metadata": {},
    "outputs": [
@@ -11010,7 +10248,7 @@
        "Washington Wizards       90.047498"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 120,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11031,7 +10269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 121,
    "id": "e9358240",
    "metadata": {},
    "outputs": [
@@ -11098,7 +10336,7 @@
        "SG               96"
       ]
      },
-     "execution_count": 125,
+     "execution_count": 121,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11119,7 +10357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 122,
    "id": "e7930de5",
    "metadata": {},
    "outputs": [
@@ -11186,7 +10424,7 @@
        "SG           3.988195"
       ]
      },
-     "execution_count": 126,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11228,7 +10466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 123,
    "id": "4c58f648",
    "metadata": {},
    "outputs": [
@@ -11309,7 +10547,7 @@
        "5   bubblegum         pink   4.75"
       ]
      },
-     "execution_count": 127,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11334,7 +10572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 124,
    "id": "6b773dec",
    "metadata": {},
    "outputs": [
@@ -11391,7 +10629,7 @@
        "strawberry      2"
       ]
      },
-     "execution_count": 128,
+     "execution_count": 124,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11418,7 +10656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 125,
    "id": "9760e80a",
    "metadata": {},
    "outputs": [
@@ -11485,7 +10723,7 @@
        "strawberry pink             2"
       ]
      },
-     "execution_count": 129,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11505,7 +10743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 126,
    "id": "53a76f26",
    "metadata": {},
    "outputs": [
@@ -11572,7 +10810,7 @@
        "strawberry pink              8.80"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11618,7 +10856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 127,
    "id": "b4505fda",
    "metadata": {},
    "outputs": [
@@ -11686,7 +10924,7 @@
        "4   chocolate   5.75"
       ]
      },
-     "execution_count": 131,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11701,7 +10939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 128,
    "id": "10af83b5",
    "metadata": {},
    "outputs": [
@@ -11757,7 +10995,7 @@
        "2     vanilla    4.0"
       ]
      },
-     "execution_count": 132,
+     "execution_count": 128,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11782,7 +11020,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 129,
    "id": "8ca6b968",
    "metadata": {},
    "outputs": [
@@ -11862,7 +11100,7 @@
        "4   chocolate   5.75   chocolate    3.5"
       ]
      },
-     "execution_count": 133,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11898,7 +11136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 130,
    "id": "1b1a9fad-3251-4ee5-9d66-e60cc16e79a1",
    "metadata": {},
    "outputs": [
@@ -11972,7 +11210,7 @@
        "4   chocolate   5.75    3.5"
       ]
      },
-     "execution_count": 134,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -11984,7 +11222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 131,
    "id": "5e51b077",
    "metadata": {},
    "outputs": [
@@ -12064,7 +11302,7 @@
        "3  strawberry   5.25    2.5  2.100000"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12092,7 +11330,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 132,
    "id": "b872a350",
    "metadata": {},
    "outputs": [
@@ -12172,7 +11410,7 @@
        "4     vanilla    4.0     vanilla   4.75"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12191,7 +11429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 137,
+   "execution_count": 133,
    "id": "285b5fa6",
    "metadata": {},
    "outputs": [
@@ -12253,7 +11491,7 @@
        "3  chocolate      4"
       ]
      },
-     "execution_count": 137,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12268,7 +11506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 134,
    "id": "5c9f83a8",
    "metadata": {},
    "outputs": [
@@ -12320,7 +11558,7 @@
        "vanilla           5.0"
       ]
      },
-     "execution_count": 138,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12340,7 +11578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 135,
    "id": "d50c1d4a",
    "metadata": {},
    "outputs": [
@@ -12400,7 +11638,7 @@
        "2  chocolate   5.75         3.5"
       ]
      },
-     "execution_count": 139,
+     "execution_count": 135,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12415,27 +11653,6 @@
    "metadata": {},
    "source": [
     "Remarquez que les cônes de fraises ont disparu. Aucun des avis ne concerne des cornets de fraises, et il n'y a donc rien à quoi les lignes `strawberry` peuvent être reliées. Cela peut être un problème ou non - cela dépend de l'analyse que nous essayons d'effectuer avec la table jointe."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a68bafad-4285-4706-aa7c-85a021a43bfb",
-   "metadata": {},
-   "source": [
-    "- Visualisation des données : regarder les données \"de la bonne manière\" couvrant 1.7 (30min)\n",
-    "\n",
-    "    - Introduction aux visualisations à l'aide de Seaborn (et conceptuellement)\n",
-    "    - avoir des exemples clairs de la bonne façon de regarder les données et des relations non triviales visibles seulement sur \"le bon graphique\"\n",
-    "    - par exemple, les relations entre les distances à différentes échelles ? quelque chose inspiré des graphiques de Nika\n",
-    "\t- prendre soin de présenter en détail l'histogramme, le principe de l'aire et la différence avec le diagramme à barres\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4e9764b2-1867-499a-bebe-9f39873296a4",
-   "metadata": {},
-   "source": [
-    "TODO : en plus du point 7 ci-dessous, ajouter un exemple de visualisation de motifs non triviaux de la \"bonne façon\"."
    ]
   },
   {
@@ -12503,7 +11720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 136,
    "id": "fea105d7",
    "metadata": {},
    "outputs": [
@@ -12671,7 +11888,7 @@
        "[50 rows x 6 columns]"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12706,7 +11923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 137,
    "id": "9a7cd7f3",
    "metadata": {},
    "outputs": [
@@ -12749,7 +11966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 142,
+   "execution_count": 138,
    "id": "3ff4a3bb",
    "metadata": {},
    "outputs": [
@@ -12790,7 +12007,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 139,
    "id": "2f6da756",
    "metadata": {},
    "outputs": [
@@ -12820,7 +12037,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 140,
    "id": "fed45c99",
    "metadata": {},
    "outputs": [
@@ -12908,7 +12125,7 @@
        "21  The Phantom Menace  474.5  "
       ]
      },
-     "execution_count": 144,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -12931,7 +12148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 141,
    "id": "8093c471",
    "metadata": {},
    "outputs": [
@@ -12986,7 +12203,7 @@
        "14  Star Wars: The Force Awakens  936.7  "
       ]
      },
-     "execution_count": 145,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13034,7 +12251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 142,
    "id": "d33f957c",
    "metadata": {},
    "outputs": [
@@ -13165,7 +12382,7 @@
        "[36 rows x 4 columns]"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 142,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13185,7 +12402,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": 143,
    "id": "a1b02f84",
    "metadata": {},
    "outputs": [
@@ -13216,7 +12433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 148,
+   "execution_count": 144,
    "id": "05cfa02b",
    "metadata": {},
    "outputs": [],
@@ -13226,7 +12443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 145,
    "id": "feb86080",
    "metadata": {},
    "outputs": [
@@ -13257,7 +12474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 150,
+   "execution_count": 146,
    "id": "1c31b0f6",
    "metadata": {},
    "outputs": [
@@ -13290,7 +12507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 151,
+   "execution_count": 147,
    "id": "07f11fb3",
    "metadata": {},
    "outputs": [
@@ -13338,7 +12555,7 @@
        "6  2009      10595.5               521   Avatar"
       ]
      },
-     "execution_count": 151,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13379,7 +12596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 152,
+   "execution_count": 148,
    "id": "fe3a5de8",
    "metadata": {},
    "outputs": [
@@ -13435,7 +12652,7 @@
        "2     Vanilla                  9"
       ]
      },
-     "execution_count": 152,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13473,7 +12690,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 153,
+   "execution_count": 149,
    "id": "abedc9c7",
    "metadata": {},
    "outputs": [
@@ -13502,7 +12719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 154,
+   "execution_count": 150,
    "id": "937f4db5",
    "metadata": {},
    "outputs": [
@@ -13538,7 +12755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 155,
+   "execution_count": 151,
    "id": "3eb3af85",
    "metadata": {},
    "outputs": [
@@ -13580,7 +12797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 156,
+   "execution_count": 152,
    "id": "a15fc2fc",
    "metadata": {},
    "outputs": [
@@ -13736,7 +12953,7 @@
        "[200 rows x 5 columns]"
       ]
      },
-     "execution_count": 156,
+     "execution_count": 152,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13758,7 +12975,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 153,
    "id": "feb6bb27",
    "metadata": {},
    "outputs": [],
@@ -13784,7 +13001,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 158,
+   "execution_count": 154,
    "id": "8b901877",
    "metadata": {},
    "outputs": [
@@ -13960,7 +13177,7 @@
        "22       Warner Brothers         29"
       ]
      },
-     "execution_count": 158,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -13980,7 +13197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 159,
+   "execution_count": 155,
    "id": "1f6e60c8",
    "metadata": {},
    "outputs": [
@@ -13990,7 +13207,7 @@
        "200"
       ]
      },
-     "execution_count": 159,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14009,7 +13226,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 160,
+   "execution_count": 156,
    "id": "a3bc5bce",
    "metadata": {},
    "outputs": [
@@ -14050,7 +13267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 161,
+   "execution_count": 157,
    "id": "307a63a5",
    "metadata": {},
    "outputs": [
@@ -14114,7 +13331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 162,
+   "execution_count": 158,
    "id": "49589e8b",
    "metadata": {
     "scrolled": true
@@ -14272,7 +13489,7 @@
        "[200 rows x 5 columns]"
       ]
      },
-     "execution_count": 162,
+     "execution_count": 158,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14294,7 +13511,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 163,
+   "execution_count": 159,
    "id": "cd194aaf",
    "metadata": {},
    "outputs": [
@@ -14401,7 +13618,7 @@
        "[200 rows x 2 columns]"
       ]
      },
-     "execution_count": 163,
+     "execution_count": 159,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14429,7 +13646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 164,
+   "execution_count": 160,
    "id": "cb519ca1",
    "metadata": {},
    "outputs": [
@@ -14439,7 +13656,7 @@
        "(338.41, 1796.18)"
       ]
      },
-     "execution_count": 164,
+     "execution_count": 160,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14459,7 +13676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 165,
+   "execution_count": 161,
    "id": "e4c44e86",
    "metadata": {},
    "outputs": [
@@ -14578,7 +13795,7 @@
        "[200 rows x 3 columns]"
       ]
      },
-     "execution_count": 165,
+     "execution_count": 161,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14598,7 +13815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 166,
+   "execution_count": 162,
    "id": "0e55d820-7453-493b-ba22-bb75c3bc356b",
    "metadata": {},
    "outputs": [
@@ -14725,7 +13942,7 @@
        "(1900, 2000]          0"
       ]
      },
-     "execution_count": 166,
+     "execution_count": 162,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14753,7 +13970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 167,
+   "execution_count": 163,
    "id": "2d186b7a",
    "metadata": {},
    "outputs": [
@@ -14815,7 +14032,7 @@
        "(1431.738, 1796.18]           2"
       ]
      },
-     "execution_count": 167,
+     "execution_count": 163,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -14846,7 +14063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 164,
    "id": "91fb116a",
    "metadata": {},
    "outputs": [
@@ -14894,7 +14111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 165,
    "id": "a499ae36",
    "metadata": {},
    "outputs": [
@@ -14997,7 +14214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 166,
    "id": "01cb9941",
    "metadata": {},
    "outputs": [
@@ -15027,7 +14244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 167,
    "id": "56ba5607",
    "metadata": {},
    "outputs": [
@@ -15154,7 +14371,7 @@
        "(1900, 2000]          0"
       ]
      },
-     "execution_count": 171,
+     "execution_count": 167,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15207,7 +14424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 168,
    "id": "a3e2452a",
    "metadata": {},
    "outputs": [
@@ -15240,7 +14457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 169,
    "id": "23b5dcdd",
    "metadata": {},
    "outputs": [
@@ -15302,7 +14519,7 @@
        "(500, 1800]         72"
       ]
      },
-     "execution_count": 173,
+     "execution_count": 169,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15324,7 +14541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 170,
    "id": "a4539b7f",
    "metadata": {},
    "outputs": [
@@ -15366,7 +14583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 171,
    "id": "7ce8760a",
    "metadata": {},
    "outputs": [
@@ -15396,7 +14613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 172,
    "id": "8017e0f9",
    "metadata": {},
    "outputs": [
@@ -15447,7 +14664,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 173,
    "id": "d9a849fd",
    "metadata": {},
    "outputs": [
@@ -15477,7 +14694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 174,
    "id": "00982aa2",
    "metadata": {},
    "outputs": [
@@ -15539,7 +14756,7 @@
        "3  (500, 1800]     72"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 174,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15560,7 +14777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 175,
    "id": "defd400a",
    "metadata": {},
    "outputs": [
@@ -15627,7 +14844,7 @@
        "3  (500, 1800]     72        0.36"
       ]
      },
-     "execution_count": 179,
+     "execution_count": 175,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15649,7 +14866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 176,
    "id": "434f9e4c",
    "metadata": {},
    "outputs": [
@@ -15721,7 +14938,7 @@
        "3  (500, 1800]     72        0.36   1300"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 176,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15746,7 +14963,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 177,
    "id": "75ac968a",
    "metadata": {},
    "outputs": [
@@ -15823,7 +15040,7 @@
        "3  (500, 1800]     72        0.36   1300  0.0003"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 177,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -15844,7 +15061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 178,
    "id": "64fcd811",
    "metadata": {},
    "outputs": [
@@ -15917,7 +15134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 179,
    "id": "6d73f066",
    "metadata": {},
    "outputs": [
@@ -16036,7 +15253,7 @@
        "[179 rows x 3 columns]"
       ]
      },
-     "execution_count": 183,
+     "execution_count": 179,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16056,7 +15273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 180,
    "id": "73a36c2c",
    "metadata": {},
    "outputs": [
@@ -16101,7 +15318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 181,
    "id": "f3b09f4f",
    "metadata": {},
    "outputs": [
@@ -16273,7 +15490,7 @@
        "18   18  4221344  4255827"
       ]
      },
-     "execution_count": 185,
+     "execution_count": 181,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16303,7 +15520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 182,
    "id": "6a1f92d2",
    "metadata": {},
    "outputs": [
@@ -16350,7 +15567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 183,
    "id": "e6cc3397",
    "metadata": {},
    "outputs": [
@@ -16436,7 +15653,7 @@
        "4          Other      3.4     3.7           6.1          6.0"
       ]
      },
-     "execution_count": 187,
+     "execution_count": 183,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -16458,7 +15675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 184,
    "id": "c92c73ac",
    "metadata": {},
    "outputs": [
@@ -16489,7 +15706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 185,
    "id": "5a580433",
    "metadata": {},
    "outputs": [
@@ -16520,7 +15737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 186,
    "id": "a6e8654c",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
Corrections après relecture d'Ambre:
L'exemple de la NBA était présent deux fois quasisment à l'identique dans le notebook (avec donc une partie de l'analyse présente deux fois à l'identique). J'ai supprimé l'exemple qui était dans le tri des lignes avec les cones au début de la partie 2. La première apparition de l'exemple sur la nba est maintenant après l'exemple sur minard.